### PR TITLE
feat(calendar): style posts list scrollbar with theme tokens

### DIFF
--- a/src/components/molecules/CalendarView.svelte
+++ b/src/components/molecules/CalendarView.svelte
@@ -324,6 +324,25 @@ function toggleDay(cell: DayCell) {
 			gap: 0.125rem
 			max-height: 9.5rem
 			overflow-y: auto
+			overscroll-behavior: contain
+			scrollbar-width: thin
+			scrollbar-color: var(--scrollbar-bg) transparent
+
+			&::-webkit-scrollbar
+				width: var(--m3e-space-2)
+
+			&::-webkit-scrollbar-track
+				background: transparent
+
+			&::-webkit-scrollbar-thumb
+				background: var(--scrollbar-bg)
+				border-radius: var(--shape-corner-full)
+
+				&:hover
+					background: var(--scrollbar-bg-hover)
+
+				&:active
+					background: var(--scrollbar-bg-active)
 
 		&__post
 			display: flex


### PR DESCRIPTION
Match the .markdown-table-scroll scrollbar pattern (thin + transparent track + token-based thumb states) for the calendar posts list and contain overscroll so scrolling does not chain to the page.

## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [ ] I have read the [**CONTRIBUTING**](https://github.com/LyraVoid/Shirone/blob/main/CONTRIBUTING.md) document.
- [ ] I have formatted my code using Biome (`pnpm format`).
- [ ] `npx astro check` passes with 0 errors.
- [ ] I have checked to ensure that this Pull Request is not for personal changes.
- [ ] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->


## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
改前：
<img width="306" height="519" alt="image" src="https://github.com/user-attachments/assets/0b65019b-6d7e-49b6-a104-f6a13156c7df" />
改后：
<img width="352" height="582" alt="image" src="https://github.com/user-attachments/assets/83c99b69-3b4f-4bdb-b80e-b880a7e79516" />

## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
