### PR TITLE
docs(packaging): record the src/ top-level directory sync rule

### DIFF
--- a/docs/packaging-contract.md
+++ b/docs/packaging-contract.md
@@ -107,6 +107,7 @@ CSS file, so it resolves to the theme's own `src/` in both modes.
 | A config module in `src/config/` | Nothing, if it follows the existing shape — the template picks it up and its relative imports are rewritten. Keep it exporting through the `src/config/index.ts` barrel. |
 | A data module in `src/data/` | Nothing. It is scaffolded to `shirones/config/data/`. Remember imports of `../config/x` become `../x` there. |
 | A component or layout | Nothing for it to work; it becomes overridable automatically. |
+| A new top-level `src/` directory | Add it to `PACKAGE_SRC_DIRS` in the shirones pipeline (`scripts/config.mjs`), or the package will not ship it and every import of it fails at build time. `src/user/` was added upstream after the integration work and missed this — it ships the config-overlay backing module. |
 | A file that is neither source nor content (`.html`, `.json`, an asset read at runtime) | Decide who owns it. Theme-owned → import it through the bundler. User-owned → ship it in the template and probe both locations. |
 
 ## Before merging into the packaged branch

--- a/rules/project-rules.md
+++ b/rules/project-rules.md
@@ -162,5 +162,6 @@ Shirone 同时以两种形态运行：**源码模式**（本仓库 checkout，`a
 5. **新增 Markdown 语法要登记 manifest**：`src/plugins/markdown/manifest.json` 的 `syntaxes` 与 `stylesheetPacks` 都要加；packs 引用的样式必须是 `src/styles/**/*.css`（`markdown-assets.ts` 只 glob `*.css`，`.styl` 会让构建抛错）。
 6. **示例文章里的仓库路径**：`@[code-tree](/src/config)`、`@include: src/content/...` 等源码态路径，在包模式要由 `shirones` 仓库的 `prepare-templates.mjs` rewrite 成 `shirones/...`；新增此类示例时在 `shirones` 仓库同步加 rewrite。
 7. **新增依赖**：主题运行时依赖必须进 `package.json` dependencies（发布会内联进 tarball），不能只装 devDependencies。
+8. **新增 `src/` 顶层目录要同步进打包清单**：`shirones` 仓库的 `scripts/config.mjs#PACKAGE_SRC_DIRS` 只复制白名单目录，新增目录（如 `src/user/`）必须加进去，否则包模式构建解析不到该目录的模块（先例：上游 `7ca4118` 引入 `src/user/user-config.ts`，被 `config-overlay.ts` 引用，漏加导致包模式 `astro:config:setup` 解析失败）。
 
 > 参考先例：上游 `feb8803` 给 `astro.config.mjs` 加了 `@shirone/iconify-offline*` 两个 alias 并改写 `Icon.svelte` 的 import，导致包模式一度解析失败；修复是镜像 alias 到 `createAliases()`（`createRequire` 定位包内 dist）。


### PR DESCRIPTION
A new top-level src/ directory must be added to PACKAGE_SRC_DIRS in the shirones pipeline or the package silently omits it and the build fails. src/user/ (the config-overlay backing module) hit exactly this after landing upstream; document the rule in the packaging contract and the §12 checklist.