### PR TITLE
fix(ogImage): 使用文章封面, 或回退設定中的第一張桌面版 Banner 作 `og:image` 和 `twitter:image`

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -26,6 +26,7 @@ import {
 import { defaultFavicons } from "../constants/icon";
 import type { Favicon } from "../types/config";
 import { createFontRoleStyle } from "../utils/font-options";
+import { resolveAsset } from "../utils/asset-utils";
 import { resolvePageWidth } from "../utils/responsive-utils";
 import { pathsEqual, url } from "../utils/url-utils";
 import "../styles/main.css";
@@ -35,13 +36,14 @@ import textureStyles from "../styles/textures.css?raw";
 interface Props {
 	title?: string;
 	banner?: string;
+	ogImage?: string;
 	description?: string;
 	lang?: string;
 	setOGTypeArticle?: boolean;
 	page?: SidebarPage;
 }
 
-let { title, description, lang, setOGTypeArticle, page } = Astro.props;
+let { title, ogImage, description, lang, setOGTypeArticle, page } = Astro.props;
 
 const initialPage =
 	page ?? (pathsEqual(Astro.url.pathname, url("/")) ? "home" : undefined);
@@ -53,6 +55,17 @@ const initialPage =
 const canonicalUrl = Astro.site
 	? new URL(Astro.url.pathname + Astro.url.search, Astro.site)
 	: Astro.url;
+const resolvedOgImage = await resolveAsset(
+	ogImage || siteConfig.banner.src.desktop[0] || "",
+);
+const absoluteOgImage = resolvedOgImage
+	? new URL(
+		resolvedOgImage.startsWith("/")
+			? url(resolvedOgImage)
+			: resolvedOgImage,
+		canonicalUrl,
+	).href
+	: "";
 
 const configHue = siteConfig.themeColor.hue;
 const lightTheme =
@@ -107,6 +120,7 @@ const hasMonoFont =
 		<meta property="og:url" content={canonicalUrl}>
 		<meta property="og:title" content={pageTitle}>
 		<meta property="og:description" content={description || pageTitle}>
+		{absoluteOgImage && <meta property="og:image" content={absoluteOgImage} />}
 		{setOGTypeArticle ? (
 			<meta property="og:type" content="article" />
 		) : (
@@ -117,6 +131,7 @@ const hasMonoFont =
 		<meta property="twitter:url" content={canonicalUrl}>
 		<meta name="twitter:title" content={pageTitle}>
 		<meta name="twitter:description" content={description || pageTitle}>
+		{absoluteOgImage && <meta name="twitter:image" content={absoluteOgImage} />}
 
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />

--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -24,6 +24,7 @@ import Layout from "./Layout.astro";
 interface Props {
 	title?: string;
 	banner?: string;
+	ogImage?: string;
 	description?: string;
 	/** Banner 可选日期，使用 YYYY-MM-DD 等可直接写入 time[datetime] 的值。 */
 	bannerDate?: string;
@@ -42,6 +43,7 @@ interface Props {
 const {
 	title,
 	banner,
+	ogImage,
 	description,
 	bannerDate,
 	lang,
@@ -61,7 +63,7 @@ const secondarySidebarClasses =
 const mainContentClasses = generateMainContentClasses(sidebarResponsive);
 ---
 
-<Layout title={title} banner={banner} description={description} lang={lang} setOGTypeArticle={setOGTypeArticle} page={page}>
+<Layout title={title} banner={banner} ogImage={ogImage} description={description} lang={lang} setOGTypeArticle={setOGTypeArticle} page={page}>
 
 <!-- Navbar -->
 <slot slot="head" name="head"></slot>

--- a/src/pages/[...permalink].astro
+++ b/src/pages/[...permalink].astro
@@ -146,6 +146,10 @@ const effectiveDescription =
 	isEncrypted && entry.data.hideHomeContent
 		? i18n(I18nKey.postEncryptedSummary)
 		: entry.data.description || entry.data.title;
+const ogImage = await resolveAsset(
+	entry.data.image,
+	imageBasePath,
+);
 
 const canonicalPostUrl = getPostUrl(entry);
 
@@ -172,7 +176,7 @@ const jsonLd = {
 };
 ---
 
-<MainGridLayout banner={entry.data.image} title={entry.data.title} description={effectiveDescription} bannerDate={formatDateToYYYYMMDD(entry.data.published)} lang={entry.data.lang} setOGTypeArticle={true} headings={effectiveHeadings} postCategory={entry.data.category || undefined} page="post" hasComments={postCommentEnabled}>
+<MainGridLayout banner={entry.data.image} ogImage={ogImage} title={entry.data.title} description={effectiveDescription} bannerDate={formatDateToYYYYMMDD(entry.data.published)} lang={entry.data.lang} setOGTypeArticle={true} headings={effectiveHeadings} postCategory={entry.data.category || undefined} page="post" hasComments={postCommentEnabled}>
     {hasMath && <link slot="head" rel="stylesheet" data-swup-optional="math" href={katexStylesheet} />}
     {hasMath && <link slot="head" rel="stylesheet" data-swup-optional="math" href={overlayScrollbarsStylesheet} />}
     {markdownStylesheetAssets.map(({ pack, css }) => <style is:inline slot="head" data-swup-optional={pack} set:html={css}></style>)}

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -147,6 +147,10 @@ const effectiveDescription =
 	isEncrypted && entry.data.hideHomeContent
 		? i18n(I18nKey.postEncryptedSummary)
 		: entry.data.description || entry.data.title;
+const ogImage = await resolveAsset(
+	entry.data.image,
+	imageBasePath,
+);
 
 const canonicalPostUrl = getPostUrl(entry);
 
@@ -173,7 +177,7 @@ const jsonLd = {
 };
 ---
 
-<MainGridLayout banner={entry.data.image} title={entry.data.title} description={effectiveDescription} bannerDate={formatDateToYYYYMMDD(entry.data.published)} lang={entry.data.lang} setOGTypeArticle={true} headings={effectiveHeadings} postCategory={entry.data.category || undefined} page="post" hasComments={postCommentEnabled}>
+<MainGridLayout banner={entry.data.image} ogImage={ogImage} title={entry.data.title} description={effectiveDescription} bannerDate={formatDateToYYYYMMDD(entry.data.published)} lang={entry.data.lang} setOGTypeArticle={true} headings={effectiveHeadings} postCategory={entry.data.category || undefined} page="post" hasComments={postCommentEnabled}>
     {hasMath && <link slot="head" rel="stylesheet" data-swup-optional="math" href={katexStylesheet} />}
     {hasMath && <link slot="head" rel="stylesheet" data-swup-optional="math" href={overlayScrollbarsStylesheet} />}
     {markdownStylesheetAssets.map(({ pack, css }) => <style is:inline slot="head" data-swup-optional={pack} set:html={css}></style>)}


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/LyraVoid/Shirone/blob/main/CONTRIBUTING.md) document.
- [x] I have formatted my code using Biome (`pnpm format`).
- [x] `npx astro check` passes with 0 errors.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->

Support for OG image social previews, when `image` was specified inside the post frontmatter for post, or fallback to use the first desktop banner if not or for other pages.

This utilized the existing `resolveAsset` helper in search of getting the required image, which then being converted to absolute URLs for social platforms. In short, this change is fully backward-compatible.

The resolved image is then being passed to the `Layout.astro`, which `og:image` and `twitter:image` metadata will be appended when available.

## How To Test

<!-- Please describe how you tested your changes. -->

### Local Test
- Opening a post with a cover image, `og:image` uses that in the generated metadata.
- Opening a post without a cover image, falls back to the desktop banner immediately.
- Verified the generated image URLs are not local paths, i.e. they are absolute paths.

### External Test

Test results from another deployed instance after the change
<img width="2880" height="1700" alt="image" src="https://github.com/user-attachments/assets/8bfc28fe-2acd-4758-a892-4629323af473" />


Facebook crawling results after the change
<img width="2154" height="1440" alt="Screenshot 2026-09-04 133543" src="https://github.com/user-attachments/assets/1a3e7183-595c-4a6d-ab88-98d74acfd5fd" />


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->

There may be some potential issues in certain deployment environments, or in simple words, when deploying on certain CF networks, this may be occured.
<img width="2142" height="1312" alt="image" src="https://github.com/user-attachments/assets/a724b1b9-0338-438b-a672-9e95b2e4c7cd" />

Unfortunately, I cannot re-produce this exact issue on my end, even from a VPS with strict networking and robots.txt requirements, or this may not be network related but image related.

If someone could repro this on their end then I may consider for another follow-up.