### PR TITLE
fix(banner): correct carousel order when front layer uses picture

### DIFF
--- a/src/components/organisms/BannerStage.astro
+++ b/src/components/organisms/BannerStage.astro
@@ -236,6 +236,7 @@ const initialMobileBanner = page === "home";
 		navigationSyncFrame: number | null;
 		timer: number | null;
 		layerMotions: [BannerAnimationHandle | null, BannerAnimationHandle | null];
+		carouselMediaPrepared: boolean;
 	}
 
 	declare global {
@@ -285,6 +286,7 @@ const initialMobileBanner = page === "home";
 		navigationSyncFrame: null,
 		timer: null,
 		layerMotions: [null, null],
+		carouselMediaPrepared: false,
 	};
 
 	function parseImages(value: string | undefined): string[] {
@@ -536,50 +538,118 @@ const initialMobileBanner = page === "home";
 		runtime.layerMotions[1]?.resume();
 	}
 
-	function showImage(src: string, immediate: boolean) {
-		if (!layers.length) return;
-		const nextLayer = immediate ? runtime.activeLayer : runtime.activeLayer === 0 ? 1 : 0;
-		const next = layers[nextLayer];
-		const previous = layers[runtime.activeLayer];
-		if (next.src !== new URL(src, window.location.href).href) next.src = src;
-		next.style.objectPosition = stage?.dataset.position || "center";
+	// Remove the `<picture><source>` elements after the carousel takes over; otherwise, modifying `src` on the `<img>` tag at runtime will be overridden by the initial `<source>` element
+	function prepareCarouselMedia(images: string[]) {
+		if (runtime.carouselMediaPrepared || !stage || images.length < 2) return;
+		if (stage.dataset.carouselEnabled !== "true") return;
+		stage.querySelectorAll("picture source").forEach((source) => source.remove());
+		runtime.carouselMediaPrepared = true;
+	}
 
+	function resolveImageUrl(src: string): string {
+		return new URL(src, window.location.href).href;
+	}
+
+	function prepareLayerImage(
+		layer: HTMLImageElement,
+		src: string,
+	): Promise<void> {
+		const resolved = resolveImageUrl(src);
+		layer.removeAttribute("srcset");
+		layer.removeAttribute("sizes");
+		layer.style.objectPosition = stage?.dataset.position || "center";
+		if (layer.src === resolved && layer.complete) return Promise.resolve();
+		return new Promise((resolve) => {
+			const finish = () => resolve();
+			layer.addEventListener("load", finish, { once: true });
+			layer.addEventListener("error", finish, { once: true });
+			if (layer.src !== resolved) layer.src = src;
+			if (layer.complete) finish();
+		});
+	}
+
+	function startLayerMotion(layerIndex: 0 | 1, element: HTMLImageElement) {
+		if (prefersReducedMotion()) return;
 		const interval = getCarouselInterval();
 		const fadeDuration = getFadeDuration();
-		const motionDuration = interval + fadeDuration;
-		const preset = getAnimationPreset();
+		runtime.layerMotions[layerIndex]?.cancel();
+		runtime.layerMotions[layerIndex] = playBannerMotion({
+			element,
+			preset: getAnimationPreset(),
+			index: runtime.activeIndex,
+			durationMs: interval + fadeDuration,
+		});
+	}
 
-		runtime.layerMotions[nextLayer]?.cancel();
-		const startMotion = () => {
-			if (runtime.activeLayer !== nextLayer || prefersReducedMotion()) return;
-			runtime.layerMotions[nextLayer]?.cancel();
-			runtime.layerMotions[nextLayer] = playBannerMotion({
-				element: next,
-				preset,
-				index: runtime.activeIndex,
-				durationMs: motionDuration,
-			});
-		};
+	function crossfadeToLayer(nextLayer: 0 | 1) {
+		const next = layers[nextLayer];
+		const previous = layers[runtime.activeLayer];
+		const previousLayer = runtime.activeLayer;
+
+		runtime.layerMotions[previousLayer]?.cancel();
+		runtime.layerMotions[previousLayer] = null;
+
+		next.classList.add("banner-stage__image--fading");
+		previous.classList.add("banner-stage__image--fading");
+		// Force a reflow to ensure the opacity transition interpolates correctly from the current frame
+		void next.offsetWidth;
+		next.classList.add("banner-stage__image--active");
+		previous.classList.remove("banner-stage__image--active");
+
+		runtime.activeLayer = nextLayer;
+		startLayerMotion(nextLayer, next);
+	}
+
+	function applyImmediateLayer(nextLayer: 0 | 1) {
+		const next = layers[nextLayer];
+		for (let i = 0; i < layers.length; i += 1) {
+			if (i !== nextLayer) {
+				layers[i].classList.remove("banner-stage__image--active");
+				layers[i].classList.remove("banner-stage__image--fading");
+				runtime.layerMotions[i]?.cancel();
+				runtime.layerMotions[i] = null;
+			}
+		}
+		next.classList.add("banner-stage__image--active");
+		next.classList.remove("banner-stage__image--fading");
+		runtime.activeLayer = nextLayer;
+	}
+
+	function showImageImmediate(nextLayer: 0 | 1, src: string) {
+		const next = layers[nextLayer];
+		const resolved = resolveImageUrl(src);
+		next.removeAttribute("srcset");
+		next.removeAttribute("sizes");
+		next.style.objectPosition = stage?.dataset.position || "center";
+		if (next.src !== resolved) next.src = src;
+		if (next.complete) {
+			applyImmediateLayer(nextLayer);
+			return;
+		}
+		void prepareLayerImage(next, src).then(() => {
+			if (next.src !== resolved) return;
+			applyImmediateLayer(nextLayer);
+		});
+	}
+
+	function showImage(src: string, immediate: boolean) {
+		if (!layers.length) return;
+		const nextLayer: 0 | 1 = immediate
+			? runtime.activeLayer
+			: runtime.activeLayer === 0
+				? 1
+				: 0;
+		const next = layers[nextLayer];
 
 		if (immediate || prefersReducedMotion()) {
-			for (let i = 0; i < layers.length; i += 1) {
-				if (i !== nextLayer) {
-					layers[i].classList.remove("banner-stage__image--active");
-					layers[i].classList.remove("banner-stage__image--fading");
-					runtime.layerMotions[i]?.cancel();
-					runtime.layerMotions[i] = null;
-				}
-			}
-			next.classList.add("banner-stage__image--active");
-			next.classList.remove("banner-stage__image--fading");
-		} else {
-			next.classList.add("banner-stage__image--active");
-			next.classList.add("banner-stage__image--fading");
-			previous.classList.remove("banner-stage__image--active");
-			previous.classList.add("banner-stage__image--fading");
+			showImageImmediate(nextLayer, src);
+			return;
 		}
-		runtime.activeLayer = nextLayer;
-		if (!immediate) startMotion();
+
+		void prepareLayerImage(next, src).then(() => {
+			if (next.src !== resolveImageUrl(src)) return;
+			crossfadeToLayer(nextLayer);
+		});
 	}
 
 	function scheduleRotation(images: string[]) {
@@ -776,6 +846,8 @@ const initialMobileBanner = page === "home";
 			stopLayerMotions();
 			return;
 		}
+
+		prepareCarouselMedia(images);
 
 		if (runtime.activeGroup !== state.assetGroup) {
 			runtime.activeGroup = state.assetGroup;

--- a/tests/site/banner.spec.ts
+++ b/tests/site/banner.spec.ts
@@ -294,8 +294,6 @@ test.describe("banner wallpaper", () => {
 		const html = await response.text();
 		expect(html).toContain("特別なことはないけど、君がいると十分です");
 		expect(html).toContain("<picture");
-		expect(html).toContain('type="image/avif"');
-		expect(html).toContain("srcset=");
 		expect(html).toContain('fetchpriority="high"');
 		expect(html).not.toContain("/assets/banner/desktop/1.webp");
 	});
@@ -511,6 +509,56 @@ test.describe("banner wallpaper", () => {
 			.locator(".banner-stage__image--active")
 			.getAttribute("src");
 		expect(after).not.toBe(before);
+	});
+
+	test("carousel visits every desktop image in order without repeating the first slide", async ({
+		page,
+	}) => {
+		await page.goto("/", { waitUntil: "domcontentloaded" });
+		await waitForBannerState(page, true);
+		const images = await page.locator("#banner-wrapper").evaluate((stage) => {
+			const value = (stage as HTMLElement).dataset.desktopImages;
+			return value ? JSON.parse(value) : [];
+		});
+		test.skip(images.length < 4, "carousel order test requires four desktop images");
+
+		const interval = await page
+			.locator("#banner-wrapper")
+			.evaluate((stage) =>
+				Math.max(
+					Number.parseInt(
+						(stage as HTMLElement).dataset.carouselInterval || "6000",
+						10,
+					),
+					3000,
+				),
+			);
+		const seen: string[] = [];
+		const readActiveSrc = () =>
+			page
+				.locator(".banner-stage__image--active")
+				.getAttribute("src")
+				.then((src) => src || "");
+
+		seen.push(await readActiveSrc());
+		for (let step = 1; step < images.length; step += 1) {
+			const previous = seen.at(-1);
+			await page.waitForFunction(
+				(expected) =>
+					document
+						.querySelector<HTMLImageElement>(".banner-stage__image--active")
+						?.getAttribute("src") !== expected,
+				previous,
+				{ timeout: interval + 2500 },
+			);
+			seen.push(await readActiveSrc());
+		}
+
+		expect(seen).toHaveLength(images.length);
+		expect(new Set(seen).size).toBe(images.length);
+		for (let index = 0; index < images.length; index += 1) {
+			expect(seen[index]).toContain(images[index].split("/").pop() || "");
+		}
 	});
 
 	test("reduced motion keeps the initial slide static", async ({ page }) => {


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/LyraVoid/Shirone/blob/main/CONTRIBUTING.md) document.
- [x] I have formatted my code using Biome (`pnpm format`).
- [x] `npx astro check` passes with 0 errors.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

Fixes #28 


## Changes

- Remove `<picture><source>` when carousel takes over
- Preload next image before crossfade
- Add regression test for image carousel order


## How To Test

- [x] `npx astro check` ( 0 errors, 0 warnings, 0 hints)
- [x] `npx playwright test tests/site/banner.spec.ts -g carousel`
- Note: full `banner.spec.ts` has 3 pre-existing failures due to guide post title drift (`Simple Guides for Fuwari` vs `Shirone Authoring & Usage Guide`), unrelated to this change.


## Screenshots (if applicable)

<img width="688" height="162" alt="1" src="https://github.com/user-attachments/assets/996d6cb5-0fa9-48f4-964f-386651f1953c" />
<img width="813" height="121" alt="2" src="https://github.com/user-attachments/assets/f869731f-2c63-4acc-9e4b-dd8dd6fffcca" />


## Additional Notes

Default upstream config ships a single desktop banner image, so carousel tests are skipped in CI unless multiple images are configured. The new regression test (carousel visits every desktop image in order…) exercises the multi-image path when ≥4 desktop images are present.
