### PR TITLE
style(markdown): enhance code collapse bottom gradient fade

### DIFF
--- a/src/styles/markdown/expressive-code.css
+++ b/src/styles/markdown/expressive-code.css
@@ -204,8 +204,14 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	height: 4.5rem;
-	background: linear-gradient(to bottom, transparent, var(--codeblock-bg));
+	height: 5.5rem;
+	background: linear-gradient(
+		to bottom,
+		transparent 0%,
+		color-mix(in srgb, var(--codeblock-bg) 35%, transparent) 35%,
+		color-mix(in srgb, var(--codeblock-bg) 85%, transparent) 75%,
+		var(--codeblock-bg) 100%
+	);
 	pointer-events: none;
 }
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please describe): UI / Style Enhancement

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/LyraVoid/Shirone/blob/main/CONTRIBUTING.md) document.
- [x] I have formatted my code using Biome (`pnpm format`).
- [x] `npx astro check` passes with 0 errors.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

Fixes #31

## Changes

- 优化 `src/styles/markdown/expressive-code.css` 中长代码块自动折叠底部的伪元素遮罩样式。
- 遮罩高度由 `4.5rem` 微调至 `5.5rem`，提供更充足的过渡区域。
- 采用 `color-mix` 构建的多阶平滑渐变衰减曲线（0% -> 35% -> 75% -> 100%），消除线性渐变带来的生硬过渡感，使折叠底部文本雾化淡出更为自然。

## How To Test

1. 运行 `pnpm dev`；
2. 打开任意包含长代码块（超过 20 行触发折叠）的文档或文章；
3. 检查折叠状态下的底部遮罩渲染，确认渐变平滑，在深色与浅色模式下均自然过渡。

## Additional Notes

纯 CSS 样式增强，不引入任何运行时或构建时额外负担。
