### PR TITLE
test(content): maintain content separation, docs, and skills for giscus provider

### DIFF
--- a/.agents/skills/shirone-config/SKILL.md
+++ b/.agents/skills/shirone-config/SKILL.md
@@ -23,7 +23,7 @@ description: Configuring a Shirone blog site - site identity, theme colors, navi
 | `sidebarConfig.ts` | 侧栏编排:`arrangement` 单/双栏、`side`、widget 清单与页面过滤 |
 | `postListConfig.ts` | 分页大小、list/grid 布局 |
 | `articleConfig.ts` | 相关文章、分享与海报 |
-| `commentConfig.ts` | 评论系统(默认关闭,Twikoo 等) |
+| `commentConfig.ts` | 评论系统(默认关闭,Twikoo / Giscus 双 Provider) |
 | `umamiConfig.ts` | Umami 数据统计：公开分享统计读取，以及可选的官方访问采集脚本 |
 | `musicConfig.ts` | 侧栏音乐(当前默认启用，可手动关闭；local/custom/meting/mixed 四种模式) |
 | `animeConfig.ts` | 追番页数据源:本地 / Bangumi 快照 / Bilibili 快照 |
@@ -45,7 +45,7 @@ description: Configuring a Shirone blog site - site identity, theme colors, navi
 
 可选功能在关闭或未配置时必须**零开销**(零请求/零 DOM/零 bundle)；是否默认启用由现有产品配置决定，不得在修改 skill 时擅自改变。启用时:
 
-1. 在对应 `*Config.ts` 置 `enable: true` 并填写凭据(如 Twikoo `envId`);
+1. 在对应 `*Config.ts` 置 `enable: true` 并填写凭据(如 Twikoo `envId`,或 Giscus 的 `giscus.repo` / `repoId` / `categoryId` 三必填——从 giscus.app 获取,缺任一则评论区静默关闭);
 2. 部分功能需同时满足多条件,如侧栏音乐要求:`musicConfig.enable` + 数据源有有效曲目 + `sidebarConfig.components` 中 music 条目 `enable: true`;
 3. 侧栏 widget 的显隐/分栏/页面范围在 `sidebarConfig.ts` 编排;
 4. 页面级开关(如 skills/projects)关闭时导航入口同步隐藏。

--- a/.agents/skills/shirone-content-config/SKILL.md
+++ b/.agents/skills/shirone-content-config/SKILL.md
@@ -23,7 +23,7 @@ description: Configure Shirone content separation and external content repositor
 3. 只在内容仓维护可物化的用户内容：`content/`、`data/`、`assets/`、`public/` 与 `config/`。挂载映射必须保持在仓库内，不能使用 `..`，不能覆盖 `scripts/`、`tests/`、`.git/` 或主题自有生成物。
 4. 将站点行为写入内容仓 `config/*.yaml`，只写需要覆盖的键。对象递归合并，数组整体替换；`nav-bar.yaml` 使用其声明式解析路径，不能按普通深合并推断。
 5. 不编辑 `src/user/user-config.ts`。它是同步生成物；需要保留代码仓中已有的有效配置时，使用 `content:export --config` 生成内容仓 YAML。
-6. 为可选外部功能保留安全默认值。关闭或配置不完整时必须没有请求、DOM 或客户端负担；凭据只放到 CI/托管平台 Secrets。Umami 的 `websiteId` 与 `scriptUrl` 是可选成对字段，只有两者同时有效才加载采集脚本。
+6. 为可选外部功能保留安全默认值。关闭或配置不完整时必须没有请求、DOM 或客户端负担；凭据只放到 CI/托管平台 Secrets。Umami 的 `websiteId` 与 `scriptUrl` 是可选成对字段，只有两者同时有效才加载采集脚本。`comment.yaml` 的 Giscus provider 需要三必填（`giscus.repo` / `repoId` / `categoryId`），缺任一等同关闭。
 
 ## 配置审阅清单
 

--- a/.agents/skills/shirone-feature/SKILL.md
+++ b/.agents/skills/shirone-feature/SKILL.md
@@ -32,7 +32,7 @@ Shirone 的可选能力(评论、统计、音乐、追番、页脚注入等)遵�
 - `docs/performance-guidelines.md` — 性能架构指南
 - `src/config/README.md` — 配置契约、config/data 判别表、新增配置项流程
 - `docs/umami-guide.md` — Umami share URL、访问采集、客户端 API 与零负担说明
-- 参考实现:`src/config/commentConfig.ts`、`src/components/organisms/comment/CommentSection.astro`、`src/components/organisms/comment/Twikoo.astro`、`src/utils/script-loader.ts`
+- 参考实现:`src/config/commentConfig.ts`、`src/components/organisms/comment/CommentSection.astro`、`src/components/organisms/comment/Twikoo.astro`、`src/components/organisms/comment/Giscus.astro`(第二 Provider:一次性 IIFE 脚本注入与主题事件同步的例外模式)、`src/utils/script-loader.ts`
 
 ## 验证命令
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Shirone keeps theme source, personal site content, and npm publishing responsibi
 | `src/config/sidebarConfig.ts` | Sidebar layout, widgets, and page filters |
 | `src/config/postListConfig.ts` | Pagination and list/grid presentation |
 | `src/config/articleConfig.ts` | Update notice, related posts, and article sharing |
-| `src/config/commentConfig.ts` | Optional comment provider |
+| `src/config/commentConfig.ts` | Optional comments via Twikoo or Giscus |
 | `src/config/musicConfig.ts` | Optional local, custom, Meting, or mixed music source |
 | `src/config/animeConfig.ts` | Anime page and local/Bangumi/Bilibili snapshot source |
 

--- a/docs/content-separation/config-overlay.md
+++ b/docs/content-separation/config-overlay.md
@@ -55,6 +55,8 @@ themeColor:
 
 `config/umami.yaml` 的 `websiteId` 与 `scriptUrl` 是可选的成对字段。省略两者时，`enable` 与 `shareUrl` 仍会启用公开统计读取；只有需要向 Umami 上报访问时才同时填写两者，单独填写任一字段不会加载采集脚本。
 
+`config/comment.yaml` 通过 `provider` 在 Twikoo 与 Giscus 之间二选一。选择 Giscus（基于 GitHub Discussions）时需同时填写 `giscus.repo`、`giscus.repoId` 与 `giscus.categoryId` 三个必填字段（从 giscus.app 配置生成器获取）；任一必填缺失时 `resolveCommentOptions()` 返回 `null`，评论区静默关闭、零额外负担。`giscus.theme` 是明暗双值对象，可以只覆盖 `dark` 一侧，另一侧沿用主题默认值（嵌套对象递归合并）。
+
 ### 自定义页脚注入 (`config/footer.html`)
 
 `config/footer.html` 是唯一的非 YAML 入口，用于注入自定义页脚 HTML 代码（如备案号、统计脚本等）。

--- a/docs/on-demand-loading.md
+++ b/docs/on-demand-loading.md
@@ -28,6 +28,7 @@
 | `src/types/commentConfig.ts` | 配置类型（字段带中文注释） |
 | `src/components/organisms/comment/CommentSection.astro` | 消费方：短路 + 动态导入 |
 | `src/components/organisms/comment/Twikoo.astro` | 特性组件：样式内嵌 + 运行时懒加载 |
+| `src/components/organisms/comment/Giscus.astro` | 第二个 Provider 参考实现：一次性脚本注入 + 主题事件同步 |
 | `src/types/stylus.d.ts` | `stylus` 包最小类型声明（构建期编译样式用） |
 | `src/utils/script-loader.ts` | `loadScriptOnce()` 动态加载第三方 SDK 并去重 |
 
@@ -59,6 +60,9 @@ if (!options || !postCommentEnabled) {
 ```
 
 - 规则：可选特性默认 `enable: false`；校验逻辑收敛在 config 的 `resolve*Options()` 里，组件只消费解析结果。
+- 多 Provider 特性（如评论的 twikoo / giscus）：`resolve*Options()` 返回判别联合，
+  每个分支校验各自的必填字段——Giscus 的 `repo` / `repoId` / `categoryId`
+  任一缺失同样返回 `null`，与未启用完全等价。
 
 ### L2 动态导入组件，避免进主 bundle
 
@@ -119,6 +123,9 @@ const twikooStyles = await new Promise<string>((resolve, reject) => {
 - **视口懒加载**：`IntersectionObserver` 进入视口（预留 `rootMargin`）才执行初始化，
   进入视口前不加载外部脚本；
 - **SDK 去重**：`loadScriptOnce(scriptUrl)` 保证同一脚本只注入一次（Swup 多次换页安全）；
+- **一次性脚本的例外**：giscus 的 `client.js` 是绑定 `document.currentScript` 的一次性
+  IIFE，复用 `loadScriptOnce()` 会让 Swup 换页后无法重新挂载；此时每次挂载注入新的
+  `<script>` 元素（HTTP 缓存下成本极低），旧元素随容器替换自然丢弃，见 `Giscus.astro`；
 - **加载状态**：优先用 CSS `:has()` 感知第三方组件的加载遮罩（如
   `&:has(> .el-loading-mask:not([style*="none"]))`），**不要**引入
   `MutationObserver` / 轮询 / 额外事件监听；

--- a/tests/content/content-config.test.mjs
+++ b/tests/content/content-config.test.mjs
@@ -439,4 +439,42 @@ describe("类型校验（真实 tsc，跑在本仓库上）", () => {
 			/config\/llms\.yaml's descriptionMaxLength/,
 		);
 	});
+
+	it("comment.yaml 的合法 giscus 覆盖通过校验（含嵌套 theme 局部覆盖）", () => {
+		const result = validate({
+			"comment.yaml": [
+				"enable: true",
+				"provider: giscus",
+				"giscus:",
+				"  repo: owner/repo",
+				"  repoId: R_placeholder",
+				"  categoryId: DIC_placeholder",
+				"  theme:",
+				"    dark: transparent_dark",
+				"",
+			].join("\n"),
+		});
+		assert.deepEqual(result.files, ["config/comment.yaml"]);
+	});
+
+	it("comment.yaml 拼错的键给出 Did you mean 提示", () => {
+		expectFailure(
+			() => validate({ "comment.yaml": "giscus:\n  repoo: owner/repo\n" }),
+			/config\/comment\.yaml's giscus\.repoo.*Did you mean to write 'repo'/s,
+		);
+	});
+
+	it("comment.yaml 越界的 provider 与 mapping 枚举会被拦下", () => {
+		expectFailure(
+			() => validate({ "comment.yaml": "provider: gisko\n" }),
+			/config\/comment\.yaml's provider/,
+		);
+		expectFailure(
+			() =>
+				validate({
+					"comment.yaml": "provider: giscus\ngiscus:\n  mapping: urlpath\n",
+				}),
+			/config\/comment\.yaml's giscus\.mapping/,
+		);
+	});
 });

--- a/tests/content/content-export.test.mjs
+++ b/tests/content/content-export.test.mjs
@@ -145,7 +145,23 @@ const CONFIG_DEFAULTS = {
 	},
 	comment: {
 		enable: false,
+		provider: "none",
 		twikoo: { envId: "", scriptUrl: "https://cdn.example.com/twikoo.js" },
+		// giscus 形状与主题真实默认值同构：嵌套 theme 明暗双值 + 空字符串占位的必填字段。
+		giscus: {
+			repo: "",
+			repoId: "",
+			category: "Announcements",
+			categoryId: "",
+			mapping: "pathname",
+			strict: false,
+			reactionsEnabled: true,
+			emitMetadata: false,
+			inputPosition: "bottom",
+			theme: { light: "light", dark: "dark" },
+			lang: "auto",
+			scriptUrl: "https://giscus.app/client.js",
+		},
 	},
 };
 
@@ -833,6 +849,41 @@ export const userConfigSources = [];
 		// 数组整体替换。
 		assert.match(read(content, "config/llms.yaml"), /- 日记/);
 		assert.doesNotMatch(read(content, "config/llms.yaml"), /secret/);
+	});
+
+	it("giscus 嵌套对象的局部覆盖只导出差异键", () => {
+		const { code, content } = createFixture();
+		write(
+			code,
+			"src/user/user-config.ts",
+			`export const userConfigOverrides = {
+	comment: {
+		enable: true,
+		provider: "giscus",
+		giscus: {
+			repo: "owner/repo",
+			repoId: "R_placeholder",
+			categoryId: "DIC_placeholder",
+			theme: { dark: "transparent_dark" },
+		},
+	},
+};
+export const userConfigSources = [];
+`,
+		);
+
+		exportRun(code, ["--yes", "--config", "--force"]);
+
+		const comment = read(content, "config/comment.yaml");
+		assert.match(comment, /enable: true/);
+		assert.match(comment, /provider: giscus/);
+		assert.match(comment, /repo: owner\/repo/);
+		assert.match(comment, /dark: transparent_dark/);
+		// theme.light 未覆盖，保持主题默认值，不该出现在最小覆盖集里。
+		assert.doesNotMatch(comment, /light:/);
+		// 与默认值相同的键（mapping、scriptUrl 等）不导出。
+		assert.doesNotMatch(comment, /mapping:/);
+		assert.doesNotMatch(comment, /scriptUrl:/);
 	});
 
 	it("新建的 YAML 带说明抬头；已有文件保留注释与格式", () => {


### PR DESCRIPTION
## Summary

Follow-up maintenance for the Giscus provider added in 0a734ec, covering everything downstream of the new `giscus` config field that the original commit didn't touch:

- **Content-separation tests** (`tests/content/`)
  - `content-config.test.mjs`: `comment.yaml` giscus cases mirroring the `llms.yaml` precedent — valid overlay with nested `theme` partial override, typo key gets `Did you mean ...?`, `provider` / `giscus.mapping` enum bounds rejected by the real `tsc` pipeline.
  - `content-export.test.mjs`: fixture `CONFIG_DEFAULTS.comment` now mirrors the giscus defaults shape, plus a nested partial export case asserting only diff keys are written (e.g. overriding only `theme.dark` keeps `theme.light` out of the minimal overlay).
- **Docs**
  - `docs/content-separation/config-overlay.md`: `config/comment.yaml` note (same style as the existing umami paired-field note) — triple-required `repo` / `repoId` / `categoryId`, silent disable via `resolveCommentOptions()` when missing, `theme` light/dark half-override via deep merge.
  - `docs/on-demand-loading.md`: add `Giscus.astro` to the reference table, the multi-provider resolve rule for `resolve*Options()`, and the one-shot IIFE script exception (why giscus can't reuse `loadScriptOnce()`).
  - `README.md`: enumerate both comment providers in the config table.
- **Skills** (`.agents/skills/`, separate commit per `rules/ai-skills.md` §4)
  - `shirone-config`: config table row + enable-pattern example with giscus triple-required fields.
  - `shirone-feature`: add `Giscus.astro` to reference implementations.
  - `shirone-content-config`: safe-default bullet now covers the giscus triple alongside umami's paired fields.

## Notes

- Branch is based on the current `main` (`de69760`); the original giscus commit is already in history, so no cherry-pick duplication.
- The content-separation pipeline itself needs no code changes — it is type-source-driven (`scripts/content/config-domains.mjs`), so `GiscusConfig` flows into `DeepPartial<CommentConfig>` validation, export diffing, and credential scanning automatically.

## Validation

- `node --test tests/content/*.test.mjs` — 137 pass (4 new cases)
- `npx astro check` — 0 errors / 0 warnings / 0 hints
- `pnpm check:manifest` — pass (skills path refs valid)
- `pnpm build` — pass; dist zero-burden scan: no comment DOM / external script / iframe
- Playwright `tests/site/comments.spec.ts` — disabled state 8 pass / 9 skip; giscus-enabled state 11 pass (iframe mount, theme sync via `shirone:theme-change`, Swup remount)
- `tests/site/a11y.spec.ts` — 34 pass with comments enabled
