### PR TITLE
fix(build): 部署的网站子路径时的资源引用问题

### DIFF
--- a/scripts/fonts/check-fonts.mjs
+++ b/scripts/fonts/check-fonts.mjs
@@ -29,7 +29,10 @@ async function walk(directory) {
 
 function resolveAssetPath(reference) {
 	const clean = reference.split(/[?#]/, 1)[0].replace(/^["']|["']$/g, "");
-	const relative = clean.replace(/^\.?\/?_astro\//, "_astro/");
+	// Strip everything before (and including) the first `_astro/` segment so
+	// sub-path deployments (base != "/") don't leak the base prefix into the
+	// resolved disk path.
+	const relative = clean.replace(/^.*?\/?_astro\//, "_astro/");
 	return join(dist, ...relative.split("/"));
 }
 

--- a/src/integration/cli.mjs
+++ b/src/integration/cli.mjs
@@ -12,7 +12,14 @@
  */
 
 import { existsSync } from "node:fs";
-import { cp, mkdir, readFile, readdir, rename, writeFile } from "node:fs/promises";
+import {
+	cp,
+	mkdir,
+	readFile,
+	readdir,
+	rename,
+	writeFile,
+} from "node:fs/promises";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
@@ -37,7 +44,10 @@ const colours = {
 const log = {
 	step: (msg) => console.log(`${colours.cyan}›${colours.reset} ${msg}`),
 	ok: (msg) => console.log(`${colours.green}✓${colours.reset} ${msg}`),
-	skip: (msg) => console.log(`${colours.dim}·${colours.reset} ${colours.dim}${msg}${colours.reset}`),
+	skip: (msg) =>
+		console.log(
+			`${colours.dim}·${colours.reset} ${colours.dim}${msg}${colours.reset}`,
+		),
 	warn: (msg) => console.log(`${colours.yellow}!${colours.reset} ${msg}`),
 	err: (msg) => console.error(`${colours.red}✗${colours.reset} ${msg}`),
 };
@@ -83,7 +93,10 @@ ${colours.dim}  shirones uses ${pmPin} — the version shipped with this release
 async function copyEntry(from, to, { force, quiet = false }) {
 	if (!existsSync(from)) return { copied: false, reason: "missing" };
 	if (existsSync(to) && !force) {
-		if (!quiet) log.skip(`${relative(CWD, to) || "."} already exists (use --force to overwrite)`);
+		if (!quiet)
+			log.skip(
+				`${relative(CWD, to) || "."} already exists (use --force to overwrite)`,
+			);
 		return { copied: false, reason: "exists" };
 	}
 	let saved;
@@ -94,7 +107,9 @@ async function copyEntry(from, to, { force, quiet = false }) {
 	await cp(from, to, { recursive: true, force: true });
 	if (!quiet) {
 		const label = relative(CWD, to) || ".";
-		log.ok(saved ? `${label} replaced (--force), kept a copy at ${saved}` : label);
+		log.ok(
+			saved ? `${label} replaced (--force), kept a copy at ${saved}` : label,
+		);
 	}
 	return { copied: true, saved };
 }
@@ -220,7 +235,11 @@ async function ensurePnpmWorkspace() {
 
 	const allowIndex = lines.findIndex((line) => /^allowBuilds:\s*$/.test(line));
 	if (allowIndex === -1) {
-		lines = [...lines.join("\n").trimEnd().split("\n"), "", ...allowBlock.split("\n")];
+		lines = [
+			...lines.join("\n").trimEnd().split("\n"),
+			"",
+			...allowBlock.split("\n"),
+		];
 	} else {
 		// Rewrite the whole indented block so placeholders become `true`.
 		let end = allowIndex + 1;
@@ -239,7 +258,10 @@ async function ensurePnpmWorkspace() {
 	}
 
 	if (!lines.some((line) => /^onlyBuiltDependencies:\s*$/.test(line))) {
-		lines = [...lines.join("\n").trimEnd().split("\n"), ...onlyBlock.split("\n")];
+		lines = [
+			...lines.join("\n").trimEnd().split("\n"),
+			...onlyBlock.split("\n"),
+		];
 	}
 
 	const next = `${lines.join("\n").trimEnd()}\n`;
@@ -263,7 +285,9 @@ async function ensurePackageJson(packageName) {
 		const version = await readPackageVersion();
 		const dependencies = {
 			astro: peers.astro ?? "^7.0.0",
-			...Object.fromEntries(Object.entries(peers).filter(([name]) => name !== "astro")),
+			...Object.fromEntries(
+				Object.entries(peers).filter(([name]) => name !== "astro"),
+			),
 			[packageName]: version ? `^${version}` : "latest",
 		};
 		const pkg = {
@@ -300,7 +324,9 @@ async function ensurePackageJson(packageName) {
 	const version = await readPackageVersion();
 	const wantedDeps = {
 		astro: peers.astro ?? "^7.0.0",
-		...Object.fromEntries(Object.entries(peers).filter(([name]) => name !== "astro")),
+		...Object.fromEntries(
+			Object.entries(peers).filter(([name]) => name !== "astro"),
+		),
 		[packageName]: version ? `^${version}` : "latest",
 	};
 
@@ -362,7 +388,9 @@ async function ensurePackageJson(packageName) {
 		log.ok("package.json");
 	}
 	for (const { dep, from, to } of upgradedDeps) {
-		log.warn(`bumped ${dep} ${from} -> ${to} — the declared version no longer satisfies the theme`);
+		log.warn(
+			`bumped ${dep} ${from} -> ${to} — the declared version no longer satisfies the theme`,
+		);
 	}
 	return [...addedDeps, ...upgradedDeps.map((d) => d.dep)];
 }
@@ -437,8 +465,12 @@ async function installRootFiles({ force }) {
 	if (added === 0 && skipped > 0) {
 		log.skip(`root files already present (${skipped} kept)`);
 	} else if (added > 0) {
-		const backupNote = backedUp ? `, ${backedUp} previous copies backed up` : "";
-		log.ok(`root files (${added} added${skipped ? `, ${skipped} kept` : ""}${backupNote})`);
+		const backupNote = backedUp
+			? `, ${backedUp} previous copies backed up`
+			: "";
+		log.ok(
+			`root files (${added} added${skipped ? `, ${skipped} kept` : ""}${backupNote})`,
+		);
 	}
 }
 
@@ -476,7 +508,8 @@ async function installDependencies() {
 	const pm = detectPackageManager();
 	// pnpm treats a CI environment as `--frozen-lockfile`, and this install
 	// exists precisely because package.json just changed — so opt out.
-	const args = pm === "pnpm" ? ["install", "--no-frozen-lockfile"] : ["install"];
+	const args =
+		pm === "pnpm" ? ["install", "--no-frozen-lockfile"] : ["install"];
 	log.step(`installing dependencies with ${pm} ${args.slice(1).join(" ")}`);
 	const result = spawnSync(pm, args, {
 		cwd: CWD,
@@ -484,7 +517,9 @@ async function installDependencies() {
 		shell: process.platform === "win32",
 	});
 	if (result.status !== 0) {
-		log.err(`${pm} install failed — run it manually and check the output above`);
+		log.err(
+			`${pm} install failed — run it manually and check the output above`,
+		);
 		process.exitCode = 1;
 		return false;
 	}
@@ -520,7 +555,11 @@ async function ensureTsConfig(packageName, { force }) {
 				paths: desiredPaths,
 			},
 		};
-		await writeFile(tsconfigPath, `${JSON.stringify(tsconfig, null, 2)}\n`, "utf8");
+		await writeFile(
+			tsconfigPath,
+			`${JSON.stringify(tsconfig, null, 2)}\n`,
+			"utf8",
+		);
 		log.ok("tsconfig.json");
 		return;
 	}
@@ -539,8 +578,16 @@ async function ensureTsConfig(packageName, { force }) {
 	}
 	if (changed) {
 		if (force) await backup("tsconfig.json");
-		await writeFile(tsconfigPath, `${JSON.stringify(tsconfig, null, 2)}\n`, "utf8");
-		log.ok(force ? "tsconfig.json (theme path aliases; previous copy backed up)" : "tsconfig.json (theme path aliases)");
+		await writeFile(
+			tsconfigPath,
+			`${JSON.stringify(tsconfig, null, 2)}\n`,
+			"utf8",
+		);
+		log.ok(
+			force
+				? "tsconfig.json (theme path aliases; previous copy backed up)"
+				: "tsconfig.json (theme path aliases)",
+		);
 	} else {
 		log.skip("tsconfig.json already configured");
 	}
@@ -579,7 +626,9 @@ async function replaceDirectory(from, to) {
 	await mkdir(dirname(to), { recursive: true });
 	await cp(from, to, { recursive: true, force: true });
 	const label = relative(CWD, to) || ".";
-	log.ok(saved ? `${label} replaced (--force), kept a copy at ${saved}` : label);
+	log.ok(
+		saved ? `${label} replaced (--force), kept a copy at ${saved}` : label,
+	);
 	return { copied: true, saved };
 }
 
@@ -593,7 +642,9 @@ async function replaceDirectory(from, to) {
  * is kept as a backup); a config that already wires the theme in is left alone.
  */
 async function ensureAstroConfig(packageName, { force }) {
-	const present = ASTRO_CONFIG_FILENAMES.filter((name) => existsSync(join(CWD, name)));
+	const present = ASTRO_CONFIG_FILENAMES.filter((name) =>
+		existsSync(join(CWD, name)),
+	);
 	const target = join(CWD, "astro.config.mjs");
 
 	for (const name of present) {
@@ -607,7 +658,9 @@ async function ensureAstroConfig(packageName, { force }) {
 
 		const saved = await backup(name);
 		if (wired) {
-			log.ok(`${name} already wires the theme in — replaced with the template (--force), kept a copy at ${saved}`);
+			log.ok(
+				`${name} already wires the theme in — replaced with the template (--force), kept a copy at ${saved}`,
+			);
 		} else {
 			log.warn(`${name} did not register the theme — kept a copy at ${saved}`);
 		}
@@ -648,7 +701,9 @@ async function clearStarterFiles() {
 				contents.includes("astro.build") ||
 				contents.includes("<slot />");
 			if (!isStarter) {
-				log.warn(`${relativePath} is yours — left in place, but it overrides the theme`);
+				log.warn(
+					`${relativePath} is yours — left in place, but it overrides the theme`,
+				);
 				continue;
 			}
 		}
@@ -663,7 +718,9 @@ async function clearStarterFiles() {
 	// A `src/pages/` that still holds routes shadows the theme's own pages.
 	const pagesDir = join(CWD, "src/pages");
 	if (existsSync(pagesDir)) {
-		const leftovers = (await readdir(pagesDir)).filter((name) => !name.startsWith("."));
+		const leftovers = (await readdir(pagesDir)).filter(
+			(name) => !name.startsWith("."),
+		);
 		if (leftovers.length > 0) {
 			log.warn(
 				`src/pages/ still contains ${leftovers.join(", ")} — ` +
@@ -682,7 +739,8 @@ async function listRelative(dir) {
 	for (const entry of await readdir(dir, { withFileTypes: true })) {
 		const full = join(dir, entry.name);
 		if (entry.isDirectory()) {
-			for (const sub of await listRelative(full)) out.push(join(entry.name, sub));
+			for (const sub of await listRelative(full))
+				out.push(join(entry.name, sub));
 		} else {
 			out.push(entry.name);
 		}
@@ -693,7 +751,8 @@ async function listRelative(dir) {
 /** Top-level `export … NAME` declarations in a TypeScript source. */
 function tsExportNames(src) {
 	const names = new Set();
-	const re = /^\s*export\s+(?:const|let|var|function|class|type|interface|enum)\s+([A-Za-z0-9_$]+)/gm;
+	const re =
+		/^\s*export\s+(?:const|let|var|function|class|type|interface|enum)\s+([A-Za-z0-9_$]+)/gm;
 	for (const m of src.matchAll(re)) names.add(m[1]);
 	return names;
 }
@@ -790,7 +849,7 @@ function objectFieldKeys(src) {
 				i = skipString(src, i);
 				continue;
 			}
-			if (ch === "{" ) {
+			if (ch === "{") {
 				open = i;
 				break;
 			}
@@ -844,7 +903,9 @@ async function checkState() {
 	const stale = usrFiles.filter((f) => !tplSet.has(f)).sort();
 
 	const fieldDiffs = [];
-	for (const rel of tplFiles.filter((f) => f.endsWith(".ts") && usrSet.has(f))) {
+	for (const rel of tplFiles.filter(
+		(f) => f.endsWith(".ts") && usrSet.has(f),
+	)) {
 		const diff = await diffConfigFile(
 			join(tplConfig, rel),
 			join(usrConfig, rel),
@@ -883,36 +944,60 @@ async function checkAndUpdate(packageName, { apply }) {
 		missingRoot.length === 0;
 
 	if (clean) {
-		console.log(`\n${colours.green}${colours.bold}Up to date.${colours.reset}\n`);
+		console.log(
+			`\n${colours.green}${colours.bold}Up to date.${colours.reset}\n`,
+		);
 		if (!apply) return;
 	} else {
 		const total =
 			missing.length + stale.length + fieldDiffs.length + missingRoot.length;
-		console.log(`\n${colours.bold}Found ${total} difference(s) from the template:${colours.reset}\n`);
+		console.log(
+			`\n${colours.bold}Found ${total} difference(s) from the template:${colours.reset}\n`,
+		);
 
 		if (missing.length) {
-			log.warn(`${missing.length} file(s) missing from ${CONTENT_ROOT}/config/`);
-			for (const f of missing) console.log(`    ${colours.dim}− ${f}${colours.reset}`);
+			log.warn(
+				`${missing.length} file(s) missing from ${CONTENT_ROOT}/config/`,
+			);
+			for (const f of missing)
+				console.log(`    ${colours.dim}− ${f}${colours.reset}`);
 		}
 		if (missingRoot.length) {
-			log.warn(`${missingRoot.length} root file(s) missing: ${missingRoot.join(", ")}`);
+			log.warn(
+				`${missingRoot.length} root file(s) missing: ${missingRoot.join(", ")}`,
+			);
 		}
 		if (stale.length) {
-			log.warn(`${stale.length} file(s) no longer exist in the template (kept)`);
-			for (const f of stale) console.log(`    ${colours.dim}− ${f}${colours.reset}`);
+			log.warn(
+				`${stale.length} file(s) no longer exist in the template (kept)`,
+			);
+			for (const f of stale)
+				console.log(`    ${colours.dim}− ${f}${colours.reset}`);
 		}
 		for (const d of fieldDiffs) {
-			log.warn(`${join(CONTENT_ROOT, "config", d.rel)} differs from the template`);
-			for (const n of d.missingExports) console.log(`    ${colours.dim}− missing export: ${n}${colours.reset}`);
-			for (const n of d.extraExports) console.log(`    ${colours.dim}− extra export (yours): ${n}${colours.reset}`);
+			log.warn(
+				`${join(CONTENT_ROOT, "config", d.rel)} differs from the template`,
+			);
+			for (const n of d.missingExports)
+				console.log(`    ${colours.dim}− missing export: ${n}${colours.reset}`);
+			for (const n of d.extraExports)
+				console.log(
+					`    ${colours.dim}− extra export (yours): ${n}${colours.reset}`,
+				);
 			for (const [name, keys] of Object.entries(d.missingFields))
-				console.log(`    ${colours.dim}− ${name}: missing field(s): ${keys.join(", ")}${colours.reset}`);
+				console.log(
+					`    ${colours.dim}− ${name}: missing field(s): ${keys.join(", ")}${colours.reset}`,
+				);
 			for (const [name, keys] of Object.entries(d.extraFields))
-				console.log(`    ${colours.dim}− ${name}: field(s) not in template: ${keys.join(", ")}${colours.reset}`);
+				console.log(
+					`    ${colours.dim}− ${name}: field(s) not in template: ${keys.join(", ")}${colours.reset}`,
+				);
 		}
 
 		if (!apply) {
-			console.log(`\n${colours.dim}Nothing was changed. Run \`npx shirones init --update\` to restore the missing files and refresh the scaffold.${colours.reset}\n`);
+			console.log(
+				`\n${colours.dim}Nothing was changed. Run \`npx shirones init --update\` to restore the missing files and refresh the scaffold.${colours.reset}\n`,
+			);
 			return;
 		}
 
@@ -926,7 +1011,9 @@ async function checkAndUpdate(packageName, { apply }) {
 					{ force: false, quiet: true },
 				);
 			}
-			log.ok(`${missing.length} file(s) restored under ${CONTENT_ROOT}/config/`);
+			log.ok(
+				`${missing.length} file(s) restored under ${CONTENT_ROOT}/config/`,
+			);
 		}
 	}
 
@@ -939,7 +1026,9 @@ async function checkAndUpdate(packageName, { apply }) {
 		join(CWD, "src/content.config.ts"),
 		{ force: false },
 	);
-	await mergeDirectory(join(TEMPLATE_DIR, "public"), join(CWD, "public"), { force: false });
+	await mergeDirectory(join(TEMPLATE_DIR, "public"), join(CWD, "public"), {
+		force: false,
+	});
 	await mkdir(join(CWD, "src/icons"), { recursive: true });
 	await installRootFiles({ force: false });
 	await ensureTsConfig(packageName, { force: false });
@@ -952,7 +1041,8 @@ async function checkAndUpdate(packageName, { apply }) {
 		log.skip("dependencies already declared");
 	}
 
-	if (!clean) console.log(`\n${colours.green}${colours.bold}Done.${colours.reset}\n`);
+	if (!clean)
+		console.log(`\n${colours.green}${colours.bold}Done.${colours.reset}\n`);
 }
 
 async function init(args) {
@@ -976,7 +1066,9 @@ async function init(args) {
 		return checkAndUpdate(packageName, { apply });
 	}
 
-	console.log(`\n${colours.bold}Shirone${colours.reset} · initialising project`);
+	console.log(
+		`\n${colours.bold}Shirone${colours.reset} · initialising project`,
+	);
 
 	// 1. Content + configuration.
 	//
@@ -1001,7 +1093,9 @@ async function init(args) {
 	if (force) {
 		await replaceDirectory(join(TEMPLATE_DIR, "public"), join(CWD, "public"));
 	} else {
-		await mergeDirectory(join(TEMPLATE_DIR, "public"), join(CWD, "public"), { force: false });
+		await mergeDirectory(join(TEMPLATE_DIR, "public"), join(CWD, "public"), {
+			force: false,
+		});
 	}
 
 	// 2b. Project root files (.env.example, .gitignore, README, editor hints, …).
@@ -1056,7 +1150,6 @@ ${colours.bold}Next${colours.reset}
 `);
 }
 
-
 async function readJsonFile(path) {
 	try {
 		return JSON.parse(await readFile(path, "utf8"));
@@ -1081,7 +1174,9 @@ async function info() {
 	const countImmediateTs = async (dir) => {
 		if (!existsSync(dir)) return 0;
 		const entries = await readdir(dir, { withFileTypes: true });
-		return entries.filter((entry) => entry.isFile() && entry.name.endsWith(".ts")).length;
+		return entries.filter(
+			(entry) => entry.isFile() && entry.name.endsWith(".ts"),
+		).length;
 	};
 	const configModules = await countImmediateTs(tplConfigDir);
 	const dataModules = await countImmediateTs(tplDataDir);
@@ -1111,36 +1206,76 @@ async function info() {
 	const currentNode = process.versions.node.split(".").map(Number);
 	const nodeOkay = nodeMatch
 		? currentNode[0] > Number(nodeMatch[1]) ||
-		  (currentNode[0] === Number(nodeMatch[1]) &&
-			(currentNode[1] > Number(nodeMatch[2]) ||
-				(currentNode[1] === Number(nodeMatch[2]) && currentNode[2] >= Number(nodeMatch[3] ?? 0))))
+			(currentNode[0] === Number(nodeMatch[1]) &&
+				(currentNode[1] > Number(nodeMatch[2]) ||
+					(currentNode[1] === Number(nodeMatch[2]) &&
+						currentNode[2] >= Number(nodeMatch[3] ?? 0))))
 		: null;
-	const nodeStatus = nodeOkay === null ? "" : nodeOkay ? ` ${colours.green}✓${colours.reset}` : ` ${colours.red}✗${colours.reset}`;
+	const nodeStatus =
+		nodeOkay === null
+			? ""
+			: nodeOkay
+				? ` ${colours.green}✓${colours.reset}`
+				: ` ${colours.red}✗${colours.reset}`;
 	const row = (label, value) => console.log(`  ${label.padEnd(20)}${value}`);
-	const section = (title) => console.log(`\n${colours.bold}${title}${colours.reset}`);
+	const section = (title) =>
+		console.log(`\n${colours.bold}${title}${colours.reset}`);
 	const listPreview = (label, values) => {
 		if (values.length === 0) return;
 		const preview = values.slice(0, 4).join(", ");
 		const more = values.length > 4 ? ` (+${values.length - 4} more)` : "";
-		console.log(`    ${colours.dim}${label}: ${preview}${more}${colours.reset}`);
+		console.log(
+			`    ${colours.dim}${label}: ${preview}${more}${colours.reset}`,
+		);
 	};
 
 	console.log(`\n${colours.bold}Shirone project info${colours.reset}`);
 	section("Package");
-	row("package", `${packageName}${packageMeta?.version ? ` v${packageMeta.version}` : ""}`);
+	row(
+		"package",
+		`${packageName}${packageMeta?.version ? ` v${packageMeta.version}` : ""}`,
+	);
 	row("package root", PACKAGE_ROOT);
-	row("template", templatePresent ? `${colours.green}present${colours.reset}` : `${colours.red}MISSING${colours.reset}`);
-	row("manifest", manifest ? `${colours.green}present${colours.reset}` : `${colours.yellow}not available${colours.reset}`);
-	row("upstream", buildInfo?.upstreamSha ? `${buildInfo.upstreamRef ?? "ref"}@${buildInfo.upstreamSha.slice(0, 12)}` : "not recorded");
-	row("built", buildInfo?.builtAt ? `${buildInfo.builtAt} (${buildInfo.node ?? "Node unknown"})` : "not recorded");
+	row(
+		"template",
+		templatePresent
+			? `${colours.green}present${colours.reset}`
+			: `${colours.red}MISSING${colours.reset}`,
+	);
+	row(
+		"manifest",
+		manifest
+			? `${colours.green}present${colours.reset}`
+			: `${colours.yellow}not available${colours.reset}`,
+	);
+	row(
+		"upstream",
+		buildInfo?.upstreamSha
+			? `${buildInfo.upstreamRef ?? "ref"}@${buildInfo.upstreamSha.slice(0, 12)}`
+			: "not recorded",
+	);
+	row(
+		"built",
+		buildInfo?.builtAt
+			? `${buildInfo.builtAt} (${buildInfo.node ?? "Node unknown"})`
+			: "not recorded",
+	);
 	row("Node", `${process.version} / requires ${engine}${nodeStatus}`);
 
 	section("Project");
 	row("project root", CWD);
-	row("status", initialized ? `${colours.green}initialised${colours.reset}` : `${colours.yellow}not initialised${colours.reset}`);
+	row(
+		"status",
+		initialized
+			? `${colours.green}initialised${colours.reset}`
+			: `${colours.yellow}not initialised${colours.reset}`,
+	);
 	row("package dependency", packageDependency);
 	row("package manager", `${detectedManager} (project: ${declaredManager})`);
-	row("content", `${join(CWD, CONTENT_ROOT)} (${contentFiles} files; ${posts} posts, ${moments} moments)`);
+	row(
+		"content",
+		`${join(CWD, CONTENT_ROOT)} (${contentFiles} files; ${posts} posts, ${moments} moments)`,
+	);
 	row("public", `${publicFiles} files`);
 	row("backup", backupFiles ? `${backupFiles} files in ${backupDir}` : "none");
 
@@ -1152,12 +1287,18 @@ async function info() {
 	row("data", `${manifestData} data modules`);
 
 	if (!initialized) {
-		console.log(`\n${colours.dim}Run \`npx shirones init\` to scaffold this project.${colours.reset}\n`);
+		console.log(
+			`\n${colours.dim}Run \`npx shirones init\` to scaffold this project.${colours.reset}\n`,
+		);
 		return;
 	}
 
 	const drift = await checkState();
-	const total = drift.missing.length + drift.stale.length + drift.fieldDiffs.length + drift.missingRoot.length;
+	const total =
+		drift.missing.length +
+		drift.stale.length +
+		drift.fieldDiffs.length +
+		drift.missingRoot.length;
 	section("Drift");
 	if (total === 0) {
 		row("status", `${colours.green}up to date${colours.reset}`);
@@ -1165,9 +1306,14 @@ async function info() {
 		row("status", `${colours.yellow}${total} difference(s)${colours.reset}`);
 		listPreview("missing config", drift.missing);
 		listPreview("stale files kept", drift.stale);
-		listPreview("changed config", drift.fieldDiffs.map((item) => item.rel));
+		listPreview(
+			"changed config",
+			drift.fieldDiffs.map((item) => item.rel),
+		);
 		listPreview("missing root", drift.missingRoot);
-		console.log(`    ${colours.dim}Run \`npx shirones init --update\` to restore safe missing files.${colours.reset}`);
+		console.log(
+			`    ${colours.dim}Run \`npx shirones init --update\` to restore safe missing files.${colours.reset}`,
+		);
 	}
 	console.log();
 }

--- a/src/integration/fonts.ts
+++ b/src/integration/fonts.ts
@@ -1,5 +1,13 @@
 import { existsSync } from "node:fs";
-import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import {
+	mkdir,
+	readFile,
+	readdir,
+	rename,
+	rm,
+	stat,
+	writeFile,
+} from "node:fs/promises";
 import { basename, extname, join } from "node:path";
 import { loadConfigModule } from "./load-config.ts";
 import type { ResolvedShironesPaths } from "./types.ts";
@@ -104,7 +112,10 @@ export async function collectSiteText(
 	}
 
 	if (subsetting.includeI18n ?? true) {
-		for (const file of await walkFiles(join(paths.packageSrc, "i18n"), [".ts", ".js"])) {
+		for (const file of await walkFiles(join(paths.packageSrc, "i18n"), [
+			".ts",
+			".js",
+		])) {
 			await absorbFile(charSet, file);
 		}
 	}
@@ -113,7 +124,11 @@ export async function collectSiteText(
 		for (const file of await walkFiles(paths.configDir, [".ts", ".js"])) {
 			await absorbFile(charSet, file);
 		}
-		for (const file of await walkFiles(paths.dataDir, [".ts", ".js", ".json"])) {
+		for (const file of await walkFiles(paths.dataDir, [
+			".ts",
+			".js",
+			".json",
+		])) {
 			await absorbFile(charSet, file);
 		}
 	}
@@ -271,7 +286,8 @@ export async function buildFontDeclarations(
 	if (!fontConfig || !resolvedFontOptions) return [];
 	if (resolvedFontOptions.mode !== "custom") return [];
 
-	const shouldSubset = options.subset && (fontConfig.subsetting?.enable ?? false);
+	const shouldSubset =
+		options.subset && (fontConfig.subsetting?.enable ?? false);
 	let subsets = new Map<string, string>();
 	if (shouldSubset) {
 		({ outputs: subsets } = await runFontSubsetting(
@@ -296,7 +312,9 @@ export async function buildFontDeclarations(
 			? { fallbacks: [], optimizedFallbacks: false }
 			: {};
 
-		const localVariants = resolvedRole.variants.filter((v) => v.source === "local");
+		const localVariants = resolvedRole.variants.filter(
+			(v) => v.source === "local",
+		);
 
 		if (localVariants.length > 0) {
 			declarations.push({
@@ -316,7 +334,9 @@ export async function buildFontDeclarations(
 							style: variant.style,
 							display: resolvedRole.display,
 							...(variant.subset ? { subset: variant.subset } : {}),
-							...(variant.unicodeRange ? { unicodeRange: variant.unicodeRange } : {}),
+							...(variant.unicodeRange
+								? { unicodeRange: variant.unicodeRange }
+								: {}),
 						};
 					}),
 				},

--- a/src/integration/index.ts
+++ b/src/integration/index.ts
@@ -12,7 +12,11 @@ import {
 } from "./load-config.ts";
 import { shironesOverlay } from "./overlay.ts";
 import { normalisePath, resolvePaths } from "./paths.ts";
-import { buildOverrideRegistry, createOverlayTargets, type OverrideRegistryRef } from "./registry.ts";
+import {
+	buildOverrideRegistry,
+	createOverlayTargets,
+	type OverrideRegistryRef,
+} from "./registry.ts";
 import { collectRoutes, filterRoutes } from "./routes.ts";
 import { shironesSsrNodeShims } from "./ssr-node-shims.ts";
 import type { ResolvedShironesPaths, ShironesOptions } from "./types.ts";
@@ -169,7 +173,9 @@ export function shirones(options: ShironesOptions = {}): AstroIntegration {
 					);
 					if (total > 0) {
 						logger.info(
-							`[overrides] ${total} registered (${Object.entries(registry.counts)
+							`[overrides] ${total} registered (${Object.entries(
+								registry.counts,
+							)
 								.map(([label, n]) => `${label}:${n}`)
 								.join(", ")})`,
 						);
@@ -184,25 +190,41 @@ export function shirones(options: ShironesOptions = {}): AstroIntegration {
 				}
 
 				// ── 1. Load user configuration (Node side) ──────────────────────
-				const siteModule = await loadConfigModule(paths, "siteConfig", registryRef);
+				const siteModule = await loadConfigModule(
+					paths,
+					"siteConfig",
+					registryRef,
+				);
 				const siteConfig = siteModule.siteConfig as {
 					site?: string;
 					base?: string;
 				};
 
-				const sidebarModule = await loadConfigModule(paths, "sidebarConfig", registryRef);
+				const sidebarModule = await loadConfigModule(
+					paths,
+					"sidebarConfig",
+					registryRef,
+				);
 				const sidebarConfig = sidebarModule.sidebarConfig as {
 					enable?: boolean;
 					components?: { type: string; enable: boolean }[];
 				};
 
-				const musicModule = await loadConfigModule(paths, "musicConfig", registryRef);
+				const musicModule = await loadConfigModule(
+					paths,
+					"musicConfig",
+					registryRef,
+				);
 				const musicConfig = musicModule.musicConfig;
 				const resolveMusicOptions = musicModule.resolveMusicOptions as (
 					c: unknown,
 				) => unknown;
 
-				const umamiModule = await loadConfigModule(paths, "umamiConfig", registryRef);
+				const umamiModule = await loadConfigModule(
+					paths,
+					"umamiConfig",
+					registryRef,
+				);
 				const umamiConfig = umamiModule.umamiConfig as { shareUrl: string };
 				const resolveUmamiOptions = umamiModule.resolveUmamiOptions as (
 					c: unknown,
@@ -430,7 +452,11 @@ async function createBundledIntegrations(
 			})
 		: null;
 
-	const ecModule = await loadConfigModule(paths, "expressiveCodeConfig", registryRef);
+	const ecModule = await loadConfigModule(
+		paths,
+		"expressiveCodeConfig",
+		registryRef,
+	);
 	const expressiveCodeConfig = ecModule.expressiveCodeConfig as {
 		theme: string;
 		lightTheme?: string;

--- a/src/integration/load-config.ts
+++ b/src/integration/load-config.ts
@@ -90,12 +90,19 @@ function overlayEsbuildPlugin(
 		setup(build: any) {
 			// Theme path aliases (`@/config/...`, `@utils/...`, ...).
 			build.onResolve(
-				{ filter: /^@(\/|components\/|utils\/|layouts\/|i18n\/|constants\/|assets\/)/ },
+				{
+					filter:
+						/^@(\/|components\/|utils\/|layouts\/|i18n\/|constants\/|assets\/)/,
+				},
 				// biome-ignore lint/suspicious/noExplicitAny: see above.
 				(args: any) => {
 					for (const [prefix, sub] of Object.entries(ALIAS_MAP)) {
 						if (!args.path.startsWith(prefix)) continue;
-						const target = join(paths.packageSrc, sub, args.path.slice(prefix.length));
+						const target = join(
+							paths.packageSrc,
+							sub,
+							args.path.slice(prefix.length),
+						);
 						const file = probeFile(target);
 						if (file) return { path: redirect(file) };
 					}

--- a/src/integration/overlay.ts
+++ b/src/integration/overlay.ts
@@ -62,7 +62,10 @@ export function shironesOverlay(options: OverlayPluginOptions): Plugin {
 					`(resolved to ${target}).`,
 			);
 		}
-		explicit.set(normalisePath(key).replace(/\.(astro|svelte|ts|js)$/, ""), target);
+		explicit.set(
+			normalisePath(key).replace(/\.(astro|svelte|ts|js)$/, ""),
+			target,
+		);
 	}
 
 	/** Explicit-map lookup for an absolute path inside the package. */
@@ -134,87 +137,90 @@ export function shironesOverlay(options: OverlayPluginOptions): Plugin {
 				return null;
 			}
 
-		// ── Case 2: relative import from a file inside the package ────────
-		if (!importer || !sourcePath.startsWith(".")) return null;
+			// ── Case 2: relative import from a file inside the package ────────
+			if (!importer || !sourcePath.startsWith(".")) return null;
 
-		const [importerPath] = splitQuery(importer);
-		const normalisedImporter = normalisePath(importerPath);
-		if (normalisedImporter.startsWith(`${packageSrc}/`)) {
-			const candidate = resolve(dirname(importerPath), sourcePath);
-			const override = overrideFor(candidate);
-			if (!override) return null;
+			const [importerPath] = splitQuery(importer);
+			const normalisedImporter = normalisePath(importerPath);
+			if (normalisedImporter.startsWith(`${packageSrc}/`)) {
+				const candidate = resolve(dirname(importerPath), sourcePath);
+				const override = overrideFor(candidate);
+				if (!override) return null;
 
-			return `${override}${query}`;
-		}
+				return `${override}${query}`;
+			}
 
-		// ── Case 3: relative import from a user override file ─────────────
-		// A mirrored component keeps the theme's own relative imports
-		// (`./PostMeta.astro`, `../../utils/…`). Resolve siblings in the
-		// user's project first; when the user hasn't mirrored them, fall back
-		// to the equivalent file inside the package.
-		const userTarget = targets.find((t) =>
-			normalisedImporter.startsWith(`${normalisePath(t.userDir)}/`),
-		);
-		if (!userTarget) return null;
+			// ── Case 3: relative import from a user override file ─────────────
+			// A mirrored component keeps the theme's own relative imports
+			// (`./PostMeta.astro`, `../../utils/…`). Resolve siblings in the
+			// user's project first; when the user hasn't mirrored them, fall back
+			// to the equivalent file inside the package.
+			const userTarget = targets.find((t) =>
+				normalisedImporter.startsWith(`${normalisePath(t.userDir)}/`),
+			);
+			if (!userTarget) return null;
 
-		const userCandidate = resolve(dirname(importerPath), sourcePath);
-		// A sibling that exists in the user's project is Vite's business.
-		if (probe(userCandidate, userTarget.extensions) || existsSync(userCandidate))
+			const userCandidate = resolve(dirname(importerPath), sourcePath);
+			// A sibling that exists in the user's project is Vite's business.
+			if (
+				probe(userCandidate, userTarget.extensions) ||
+				existsSync(userCandidate)
+			)
+				return null;
+
+			// Otherwise resolve the equivalent file inside the package — this also
+			// covers non-component files (`.css`, assets) a mirrored file reaches.
+			const rel = relative(userTarget.userDir, userCandidate);
+			const pkgCandidate = join(userTarget.packageDir, rel);
+			const pkgTarget =
+				probe(pkgCandidate, userTarget.extensions) ??
+				(existsSync(pkgCandidate) ? pkgCandidate : null);
+			if (pkgTarget) return `${normalisePath(pkgTarget)}${query}`;
 			return null;
+		},
 
-		// Otherwise resolve the equivalent file inside the package — this also
-		// covers non-component files (`.css`, assets) a mirrored file reaches.
-		const rel = relative(userTarget.userDir, userCandidate);
-		const pkgCandidate = join(userTarget.packageDir, rel);
-		const pkgTarget =
-			probe(pkgCandidate, userTarget.extensions) ??
-			(existsSync(pkgCandidate) ? pkgCandidate : null);
-		if (pkgTarget) return `${normalisePath(pkgTarget)}${query}`;
-		return null;
-	},
+		load(id) {
+			// User-overridden .astro/.svelte files keep the theme's relative
+			// Stylus imports (`@import "../styles/…"`), which only exist inside
+			// the package. Rewrite them here — in `load` rather than `transform` —
+			// because vite-plugin-astro compiles `<style lang="stylus">` in its own
+			// pre-transform, which runs before this plugin's transform hook.
+			const [path, query] = splitQuery(id);
+			if (query) return null;
+			const normalised = normalisePath(path);
+			if (!/\.(astro|svelte)$/.test(normalised)) return null;
+			const target = targets.find((t) =>
+				normalised.startsWith(`${normalisePath(t.userDir)}/`),
+			);
+			if (!target) return null;
 
-	load(id) {
-		// User-overridden .astro/.svelte files keep the theme's relative
-		// Stylus imports (`@import "../styles/…"`), which only exist inside
-		// the package. Rewrite them here — in `load` rather than `transform` —
-		// because vite-plugin-astro compiles `<style lang="stylus">` in its own
-		// pre-transform, which runs before this plugin's transform hook.
-		const [path, query] = splitQuery(id);
-		if (query) return null;
-		const normalised = normalisePath(path);
-		if (!/\.(astro|svelte)$/.test(normalised)) return null;
-		const target = targets.find((t) =>
-			normalised.startsWith(`${normalisePath(t.userDir)}/`),
-		);
-		if (!target) return null;
+			let code: string;
+			try {
+				code = readFileSync(path, "utf8");
+			} catch {
+				return null;
+			}
+			if (!/@(import|reference|require)\s+["']\.\.?\//.test(code)) return null;
 
-		let code: string;
-		try {
-			code = readFileSync(path, "utf8");
-		} catch {
-			return null;
-		}
-		if (!/@(import|reference|require)\s+["']\.\.?\//.test(code)) return null;
-
-		let changed = false;
-		const out = code.replace(
-			/@(import|reference|require)\s+(["'])(\.\.?\/[^"']+)\2/g,
-			(match, directive, quote, rel) => {
-				// Resolve against the user's project first, so a user can also
-				// override the referenced file; otherwise point at the package's
-				// copy (`.styl` variables, `.css` imports, `@reference` targets).
-				const candidate = resolve(dirname(path), rel);
-				if (existsSync(candidate)) return match;
-				const pkgTarget = join(
-					target.packageDir,
-					relative(target.userDir, candidate),
-				);
-				if (!existsSync(pkgTarget)) return match;
-				changed = true;
-				return `@${directive} ${quote}${normalisePath(pkgTarget)}${quote}`;
-			},
-		);
-		return changed ? { code: out, map: null } : null;
-	},
-};
+			let changed = false;
+			const out = code.replace(
+				/@(import|reference|require)\s+(["'])(\.\.?\/[^"']+)\2/g,
+				(match, directive, quote, rel) => {
+					// Resolve against the user's project first, so a user can also
+					// override the referenced file; otherwise point at the package's
+					// copy (`.styl` variables, `.css` imports, `@reference` targets).
+					const candidate = resolve(dirname(path), rel);
+					if (existsSync(candidate)) return match;
+					const pkgTarget = join(
+						target.packageDir,
+						relative(target.userDir, candidate),
+					);
+					if (!existsSync(pkgTarget)) return match;
+					changed = true;
+					return `@${directive} ${quote}${normalisePath(pkgTarget)}${quote}`;
+				},
+			);
+			return changed ? { code: out, map: null } : null;
+		},
+	};
 }

--- a/src/integration/paths.ts
+++ b/src/integration/paths.ts
@@ -34,7 +34,9 @@ export function findPackageRoot(fromUrl: string): string {
  * from a checkout of the Shirone repository. Mirrors Starlight/Stalux detection.
  */
 export function detectPluginMode(fromUrl: string): boolean {
-	return fromUrl.includes("/node_modules/") || fromUrl.includes("\\node_modules\\");
+	return (
+		fromUrl.includes("/node_modules/") || fromUrl.includes("\\node_modules\\")
+	);
 }
 
 function toAbsolute(projectRoot: string, candidate: string): string {

--- a/src/integration/registry.ts
+++ b/src/integration/registry.ts
@@ -45,7 +45,9 @@ export interface OverlayTarget {
  * | `src/components/**` | `src/components/**`          |
  * | `src/layouts/**`    | `src/layouts/**`             |
  */
-export function createOverlayTargets(paths: ResolvedShironesPaths): OverlayTarget[] {
+export function createOverlayTargets(
+	paths: ResolvedShironesPaths,
+): OverlayTarget[] {
 	return [
 		{
 			label: "config",
@@ -149,7 +151,9 @@ export interface OverrideRegistry {
  * probe per import, and the registry doubles as the single source of truth for
  * "what is overridden and what is not".
  */
-export function buildOverrideRegistry(paths: ResolvedShironesPaths): OverrideRegistry {
+export function buildOverrideRegistry(
+	paths: ResolvedShironesPaths,
+): OverrideRegistry {
 	const targets = createOverlayTargets(paths);
 	const overrides = new Map<string, string>();
 	const counts: Record<string, number> = {};

--- a/src/integration/routes.ts
+++ b/src/integration/routes.ts
@@ -107,6 +107,7 @@ export function filterRoutes(
 		exclude.map((value) => (value.startsWith("/") ? value : `/${value}`)),
 	);
 	return routes.filter(
-		(route) => !normalised.has(route.pattern) && !normalised.has(`/${route.source}`),
+		(route) =>
+			!normalised.has(route.pattern) && !normalised.has(`/${route.source}`),
 	);
 }

--- a/src/integration/ssr-node-shims.ts
+++ b/src/integration/ssr-node-shims.ts
@@ -61,8 +61,9 @@ export function shironesSsrNodeShims(): Plugin {
 		renderChunk(code) {
 			if (!isSsr) return null;
 
-			const filenameDeclared =
-				/(?:const|let|var|function)\s+__filename\b/.test(code);
+			const filenameDeclared = /(?:const|let|var|function)\s+__filename\b/.test(
+				code,
+			);
 			const needsFilename =
 				/(?<![\w$.])__filename(?![\w$])/.test(code) && !filenameDeclared;
 			const needsDirname =

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -9,7 +9,11 @@ export const GET: APIRoute = async (context: APIContext) => {
 		return new Response("Not Found", { status: 404 });
 	}
 
-	const siteUrl = (context.site?.href ?? siteConfig.site ?? "https://shirone.mysqil.com").replace(/\/$/, "");
+	const siteUrl = (
+		context.site?.href ??
+		siteConfig.site ??
+		"https://shirone.mysqil.com"
+	).replace(/\/$/, "");
 	const allPosts = await getSortedPosts();
 
 	// 严格安全与隐私过滤：排除加密文章、草稿以及黑名单标签/分类

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -9,7 +9,11 @@ export const GET: APIRoute = async (context: APIContext) => {
 		return new Response("Not Found", { status: 404 });
 	}
 
-	const siteUrl = (context.site?.href ?? siteConfig.site ?? "https://shirone.mysqil.com").replace(/\/$/, "");
+	const siteUrl = (
+		context.site?.href ??
+		siteConfig.site ??
+		"https://shirone.mysqil.com"
+	).replace(/\/$/, "");
 	const allPosts = await getSortedPosts();
 
 	// 严格安全与隐私过滤：排除加密文章、草稿以及黑名单标签/分类

--- a/src/plugins/markdown/containers/rehype-fields.mjs
+++ b/src/plugins/markdown/containers/rehype-fields.mjs
@@ -1,28 +1,51 @@
 import { h } from "hastscript";
 
-const TAGS = new Set(["name", "type", "default", "required", "optional", "deprecated", "description"]);
+const TAGS = new Set([
+	"name",
+	"type",
+	"default",
+	"required",
+	"optional",
+	"deprecated",
+	"description",
+]);
 
 function textContent(node) {
 	if (!node) return "";
 	if (Array.isArray(node)) return node.map(textContent).join("");
 	if (node.type === "text") return node.value || "";
-	return Array.isArray(node.children) ? node.children.map(textContent).join("") : "";
+	return Array.isArray(node.children)
+		? node.children.map(textContent).join("")
+		: "";
 }
 
 function parseMetadata(children, fallbackName) {
 	const metadata = { name: fallbackName };
 	const body = [];
 	for (const child of Array.isArray(children) ? children : []) {
-		if (child.type !== "element" || child.tagName !== "p") { body.push(child); continue; }
-		const lines = textContent(child).split("\n").map((line) => line.trim()).filter(Boolean);
-		if (!lines.length || lines.some((line) => !line.startsWith("@"))) { body.push(child); continue; }
+		if (child.type !== "element" || child.tagName !== "p") {
+			body.push(child);
+			continue;
+		}
+		const lines = textContent(child)
+			.split("\n")
+			.map((line) => line.trim())
+			.filter(Boolean);
+		if (!lines.length || lines.some((line) => !line.startsWith("@"))) {
+			body.push(child);
+			continue;
+		}
 		let recognized = true;
 		for (const line of lines) {
 			const match = line.match(/^@([a-z]+)(?:\s+(.*))?$/i);
-			if (!match || !TAGS.has(match[1].toLowerCase())) { recognized = false; break; }
+			if (!match || !TAGS.has(match[1].toLowerCase())) {
+				recognized = false;
+				break;
+			}
 			const tag = match[1].toLowerCase();
 			const value = (match[2] || "").trim().replace(/^`|`$/g, "");
-			if (["required", "optional", "deprecated"].includes(tag)) metadata[tag] = true;
+			if (["required", "optional", "deprecated"].includes(tag))
+				metadata[tag] = true;
 			else if (value) metadata[tag] = value;
 		}
 		if (!recognized) body.push(child);
@@ -31,7 +54,11 @@ function parseMetadata(children, fallbackName) {
 }
 
 export function FieldGroupComponent(_properties, children = []) {
-	return h("div", { class: "m3-field-group not-prose", "data-field-group": true }, children);
+	return h(
+		"div",
+		{ class: "m3-field-group not-prose", "data-field-group": true },
+		children,
+	);
 }
 
 export function FieldComponent(properties = {}, children = []) {
@@ -42,12 +69,30 @@ export function FieldComponent(properties = {}, children = []) {
 	}
 	const { metadata, body } = parseMetadata(content, label);
 	const name = metadata.name || String(properties.name || "").trim();
-	const status = metadata.required ? properties["label-required"] : metadata.optional ? properties["label-optional"] : metadata.deprecated ? properties["label-deprecated"] : "";
+	const status = metadata.required
+		? properties["label-required"]
+		: metadata.optional
+			? properties["label-optional"]
+			: metadata.deprecated
+				? properties["label-deprecated"]
+				: "";
 	const meta = [h("span", { class: "m3-field__name" }, name)];
-	if (status) meta.push(h("span", { class: `m3-field__status m3-field__status--${metadata.required ? "required" : metadata.deprecated ? "deprecated" : "optional"}` }, status));
-	if (metadata.type) meta.push(h("code", { class: "m3-field__type" }, metadata.type));
+	if (status)
+		meta.push(
+			h(
+				"span",
+				{
+					class: `m3-field__status m3-field__status--${metadata.required ? "required" : metadata.deprecated ? "deprecated" : "optional"}`,
+				},
+				status,
+			),
+		);
+	if (metadata.type)
+		meta.push(h("code", { class: "m3-field__type" }, metadata.type));
 	const output = [h("div", { class: "m3-field__meta" }, meta)];
-	if (metadata.default) output.push(h("code", { class: "m3-field__default" }, metadata.default));
-	if (body.length) output.push(h("div", { class: "m3-field__description" }, body));
+	if (metadata.default)
+		output.push(h("code", { class: "m3-field__default" }, metadata.default));
+	if (body.length)
+		output.push(h("div", { class: "m3-field__description" }, body));
 	return h("div", { class: "m3-field", "data-field": true }, output);
 }

--- a/src/plugins/markdown/manifest.json
+++ b/src/plugins/markdown/manifest.json
@@ -746,20 +746,54 @@
 			"category": "container",
 			"source": "shirone",
 			"summary": "将 API、组件 Props 或配置字段渲染为结构化参数卡片。",
-			"forms": [{"kind": "container-directive", "pattern": ":::: field-group ... ::: field name ... ::::", "example": ":::: field-group\\n\\n::: field title\\n@type string\\n@optional\\n\\nDescription.\\n:::\\n\\n::::"}],
-			"attributes": [
-				{"name": "name", "required": true, "values": "non-empty text", "default": null},
-				{"name": "@type", "required": false, "values": "text", "default": null},
-				{"name": "@default", "required": false, "values": "text", "default": null},
-				{"name": "@required | @optional | @deprecated", "required": false, "values": "flag", "default": null}
+			"forms": [
+				{
+					"kind": "container-directive",
+					"pattern": ":::: field-group ... ::: field name ... ::::",
+					"example": ":::: field-group\\n\\n::: field title\\n@type string\\n@optional\\n\\nDescription.\\n:::\\n\\n::::"
+				}
 			],
-			"implementation": ["src/plugins/markdown/remark-fields.mjs", "src/plugins/markdown/containers/rehype-fields.mjs"],
+			"attributes": [
+				{
+					"name": "name",
+					"required": true,
+					"values": "non-empty text",
+					"default": null
+				},
+				{
+					"name": "@type",
+					"required": false,
+					"values": "text",
+					"default": null
+				},
+				{
+					"name": "@default",
+					"required": false,
+					"values": "text",
+					"default": null
+				},
+				{
+					"name": "@required | @optional | @deprecated",
+					"required": false,
+					"values": "flag",
+					"default": null
+				}
+			],
+			"implementation": [
+				"src/plugins/markdown/remark-fields.mjs",
+				"src/plugins/markdown/containers/rehype-fields.mjs"
+			],
 			"registeredIn": "src/utils/markdown-processor.mjs",
 			"styles": ["src/styles/markdown/fields.css"],
-			"runtime": {"mode": "none", "modules": [], "network": []},
-			"docs": ["src/content/posts/markdown-fields.md", "docs/markdown-extensions.md"],
+			"runtime": { "mode": "none", "modules": [], "network": [] },
+			"docs": [
+				"src/content/posts/markdown-fields.md",
+				"docs/markdown-extensions.md"
+			],
 			"tests": ["tests/plugins/markdown/containers/fields.test.mjs"],
-			"notes": ["无效或不完整的字段标签保留为可读 Markdown；组件为纯 SSR 输出，不增加客户端运行时。"]
+			"notes": [
+				"无效或不完整的字段标签保留为可读 Markdown；组件为纯 SSR 输出，不增加客户端运行时。"
+			]
 		},
 		{
 			"id": "file-tree",
@@ -882,8 +916,8 @@
 					"kind": "container-directive",
 					"pattern": ":::grid{columns=\"1..6\" aspect=\"W/H\" fit=\"cover|contain\"} ... :::",
 					"example": ":::grid{columns=\"3\" aspect=\"16/9\" fit=\"cover\"}\n![说明](./one.webp)\n![说明](./two.webp)\n:::"
-		}
-	],
+				}
+			],
 			"attributes": [
 				{
 					"name": "columns",
@@ -955,10 +989,7 @@
 				"modules": [],
 				"network": ["author-declared image URLs only"]
 			},
-			"docs": [
-				"src/content/posts/spoilers.md",
-				"docs/markdown-extensions.md"
-			],
+			"docs": ["src/content/posts/spoilers.md", "docs/markdown-extensions.md"],
 			"tests": ["tests/plugins/rehype-markdown-images.test.mjs"],
 			"notes": ["非法或越界宽度令牌保留在 alt，不静默改写。"]
 		},

--- a/src/plugins/markdown/remark-fields.mjs
+++ b/src/plugins/markdown/remark-fields.mjs
@@ -4,18 +4,26 @@ const FIELD_OPENER = /^(\s*)(:{3,})[\t ]*field(?:-group)?(?:[\t ]|$)/i;
 export function remarkFields() {
 	const parser = this.parser;
 	this.parser = function parseFields(source) {
-		if (typeof source !== "string" || !source.includes("field")) return parser(source);
-		const normalized = source.split(/(\r?\n)/).map((part) => {
-			const match = part.match(FIELD_OPENER);
-			if (!match) return part;
-			const prefix = part.slice(0, match[0].length - match[0].trimStart().length);
-			const marker = match[2];
-			const rest = part.slice(match[0].length).trim();
-			const name = /field-group/i.test(match[0]) ? "field-group" : "field";
-			if (name === "field-group" || !rest) return `${prefix}${marker}${name}`;
-			if (rest.startsWith("{") || rest.startsWith("[")) return `${prefix}${marker}${name}${rest}`;
-			return `${prefix}${marker}${name}{name="${rest.replaceAll('"', '&quot;')}"}`;
-		}).join("");
+		if (typeof source !== "string" || !source.includes("field"))
+			return parser(source);
+		const normalized = source
+			.split(/(\r?\n)/)
+			.map((part) => {
+				const match = part.match(FIELD_OPENER);
+				if (!match) return part;
+				const prefix = part.slice(
+					0,
+					match[0].length - match[0].trimStart().length,
+				);
+				const marker = match[2];
+				const rest = part.slice(match[0].length).trim();
+				const name = /field-group/i.test(match[0]) ? "field-group" : "field";
+				if (name === "field-group" || !rest) return `${prefix}${marker}${name}`;
+				if (rest.startsWith("{") || rest.startsWith("["))
+					return `${prefix}${marker}${name}${rest}`;
+				return `${prefix}${marker}${name}{name="${rest.replaceAll('"', "&quot;")}"}`;
+			})
+			.join("");
 		return parser(normalized);
 	};
 }

--- a/src/plugins/remark-feature-probes.mjs
+++ b/src/plugins/remark-feature-probes.mjs
@@ -141,7 +141,10 @@ export function remarkFeatureProbes() {
 			if (node.type === "containerDirective" && node.name === "tabs") {
 				syntaxes.add("option-groups");
 			}
-			if (node.type === "containerDirective" && ["field", "field-group"].includes(node.name)) {
+			if (
+				node.type === "containerDirective" &&
+				["field", "field-group"].includes(node.name)
+			) {
 				syntaxes.add("fields");
 			}
 		});

--- a/src/utils/content-date.ts
+++ b/src/utils/content-date.ts
@@ -57,8 +57,16 @@ function getDateParts(date: Date, timeZone: string): DateParts {
 			.map(({ type, value }) => [type, value]),
 	) as Partial<DateParts>;
 
-	if (!values.year || !values.month || !values.day || !values.hour || !values.minute) {
-		throw new Error("Unable to extract date parts for the configured time zone.");
+	if (
+		!values.year ||
+		!values.month ||
+		!values.day ||
+		!values.hour ||
+		!values.minute
+	) {
+		throw new Error(
+			"Unable to extract date parts for the configured time zone.",
+		);
 	}
 
 	return values as DateParts;
@@ -70,7 +78,10 @@ export function formatCalendarDate(date: Date): string {
 	return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
 }
 
-export function formatInstantDateInTimeZone(date: Date, timeZone: string): string {
+export function formatInstantDateInTimeZone(
+	date: Date,
+	timeZone: string,
+): string {
 	const parts = getDateParts(date, timeZone);
 	return `${parts.year}-${parts.month}-${parts.day}`;
 }
@@ -108,13 +119,16 @@ export function validatePublicationMetadata(
 	timeZone: string = siteConfig.timeZone,
 ): void {
 	if (!isValidTimeZone(timeZone)) {
-		throw new Error(`siteConfig.timeZone must be a valid IANA time zone; received "${timeZone}".`);
+		throw new Error(
+			`siteConfig.timeZone must be a valid IANA time zone; received "${timeZone}".`,
+		);
 	}
 
 	const publishedDate = formatCalendarDate(entry.data.published);
 	if (
 		entry.data.publishedAt &&
-		formatInstantDateInTimeZone(entry.data.publishedAt, timeZone) !== publishedDate
+		formatInstantDateInTimeZone(entry.data.publishedAt, timeZone) !==
+			publishedDate
 	) {
 		throw new Error(
 			`Post "${entry.id}" has publishedAt outside its published calendar date in ${timeZone}.`,
@@ -132,7 +146,9 @@ export function validatePublicationMetadata(
 		);
 	}
 	if (entry.data.updatedAt && !entry.data.updated) {
-		throw new Error(`Post "${entry.id}" must define updated alongside updatedAt.`);
+		throw new Error(
+			`Post "${entry.id}" must define updated alongside updatedAt.`,
+		);
 	}
 }
 

--- a/src/utils/spoilers.ts
+++ b/src/utils/spoilers.ts
@@ -17,7 +17,5 @@ function wire(button: HTMLButtonElement): void {
 /** Adds touch and keyboard toggling to SSR-native spoiler buttons. */
 export function initSpoilers(container: ParentNode = document): void {
 	if (typeof document === "undefined") return;
-	container
-		.querySelectorAll<HTMLButtonElement>(SPOILER_SELECTOR)
-		.forEach(wire);
+	container.querySelectorAll<HTMLButtonElement>(SPOILER_SELECTOR).forEach(wire);
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/LyraVoid/Shirone/blob/main/CONTRIBUTING.md) document.
- [x] I have formatted my code using Biome (`pnpm format`).
- [x] `npx astro check` passes with 0 errors.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

#45 

## Changes

At the end of `pnpm build`, it will check the font file, at file `scripts/fonts/check-fonts.mjs`.

The original regex `/^.? /?_astro//` can only strip paths starting with `/_astro/`. When the base is set to `/my-website`, the input in function `resolveAssetPath` is `/my-website/_astro/fonts/xxx.woff2`. The regular script only strips `/_astro/`, leaving `my-website/_astro/fonts/xxx.woff2`, and when concatenated with `dist`, it becomes `dist/my-website/_astro/fonts/xxx.woff2`, while the actual file is `dist/_astro/fonts/xxx.woff2`.

## How To Test

Deploy with baseURL has sub path, for example https://example.com/my-website

1. Edit `src/config/siteConfig.ts` in theme repo or `config/site.yaml` in content repo, update the `site` and `base` field with corresponding value.
2. Run command `pnpm build`

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
